### PR TITLE
Fix the order of addition of CFLAGS

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,5 +1,3 @@
-CFLAGS += -Wall -Wno-switch -Wno-parentheses -Wno-unused-variable -Wno-unused-but-set-variable -Wextra -Wno-unused-parameter -Wno-sign-compare -Wmissing-prototypes -DLIBRETRO=1
-
 SOURCES_C := $(CORE_DIR)/access.c $(CORE_DIR)/boot.c $(CORE_DIR)/branch.c \
 	$(CORE_DIR)/covox.c $(CORE_DIR)/double.c $(CORE_DIR)/ea.c \
 	$(CORE_DIR)/itab.c \

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -522,6 +522,8 @@ fpic=
 SHARED=
 endif
 
+CFLAGS += -Wall -Wno-switch -Wno-parentheses -Wno-unused-variable -Wno-unused-but-set-variable -Wextra -Wno-unused-parameter -Wno-sign-compare -Wmissing-prototypes -DLIBRETRO=1
+
 ifeq ($(DEBUG), 1)
 ifneq (,$(findstring msvc,$(platform)))
 	ifeq ($(STATIC_LINKING),1)


### PR DESCRIPTION
CFLAGS from Makefile.common get overwritten by Makefile.
This breaks libnx as -DLIBRETRO is missing, change the order to fix this