### PR TITLE
Add explicit srd=gnu99 for consistency

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -134,7 +134,7 @@ else ifeq ($(platform), psp1)
    AR = psp-ar$(EXE_EXT)
    CFLAGS += -DPSP -G0
    CXXFLAGS += -DPSP -G0
-   CFLAGS += -I$(shell psp-config --pspsdk-path)/include -std=gnu99
+   CFLAGS += -I$(shell psp-config --pspsdk-path)/include
    STATIC_LINKING = 1
 # QNX
 else ifeq ($(platform), qnx)
@@ -251,8 +251,7 @@ else ifeq ($(platform), libnx)
                  -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec -Wl,--allow-multiple-definition -specs=$(LIBNX)/switch.specs
     CFLAGS += $(INCDIRS)
     CFLAGS	+=	-D__SWITCH__ -DHAVE_LIBNX -march=armv8-a -mtune=cortex-a57 -mtp=soft
-    CXXFLAGS := $(ASFLAGS) $(CFLAGS) -fno-rtti -std=gnu++11
-    CFLAGS += -std=gnu11
+    CXXFLAGS := $(ASFLAGS) $(CFLAGS) -fno-rtti
     STATIC_LINKING = 1
 
 # Classic Platforms ####################
@@ -530,6 +529,7 @@ SHARED=
 endif
 
 CFLAGS += -Wall -Wno-switch -Wno-parentheses -Wno-unused-variable -Wno-unused-but-set-variable -Wextra -Wno-unused-parameter -Wno-sign-compare -Wmissing-prototypes -DLIBRETRO=1
+CFLAGS += -std=gnu99
 
 ifeq ($(DEBUG), 1)
 ifneq (,$(findstring msvc,$(platform)))


### PR DESCRIPTION
QNX compiler defaults to a different standard. Let's just settle on one
standard for all platforms