### PR TITLE
osx: Remove default ARCHFLAGS.

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -45,14 +45,6 @@ LIBS := -lm
 endif
 fpic=
 
-ifeq ($(ARCHFLAGS),)
-ifeq ($(archs),ppc)
-   ARCHFLAGS = -arch ppc -arch ppc64
-else
-   ARCHFLAGS = -arch i386 -arch x86_64
-endif
-endif
-
 ifeq ($(STATIC_LINKING),1)
 	EXT=a
 


### PR DESCRIPTION
Recent XCode doesn't have libs for i386. Hence leave it at intrinsic default
unless user overrides it